### PR TITLE
Delete skill

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,7 +82,5 @@ def skill():
         if index is not None and 0 <= index < len(data["skill"]):
             deleted_skill = data["skill"].pop(index)
             return jsonify({"message": f"Skill '{deleted_skill.name}' deleted successfully"})
-        else:
-            return jsonify({"error": "Invalid index position"}), 400
 
     return jsonify({})

--- a/app.py
+++ b/app.py
@@ -66,7 +66,7 @@ def education():
     return jsonify({})
 
 
-@app.route('/resume/skill', methods=['GET', 'POST'])
+@app.route('/resume/skill', methods=['GET', 'POST', 'DELETE'])
 def skill():
     '''
     Handles Skill requests
@@ -76,5 +76,13 @@ def skill():
 
     if request.method == 'POST':
         return jsonify({})
+
+    if request.method == 'DELETE':
+        index = request.args.get("index", type=int)
+        if index is not None and 0 <= index < len(data["skill"]):
+            deleted_skill = data["skill"].pop(index)
+            return jsonify({"message": f"Skill '{deleted_skill.name}' deleted successfully"})
+        else:
+            return jsonify({"error": "Invalid index position"}), 400
 
     return jsonify({})

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -84,14 +84,14 @@ def test_delete_skill():
 
     item_id = app.test_client().post('/resume/skill', json=example_skill).json['id']
 
-    index_to_delete = 0  
-    skill_name = example_skill["skill"][index_to_delete]
+    index_to_delete = 0
     response = app.test_client().delete(f'/resume/skill?index={index_to_delete}')
+    assert response.json[item_id] == example_skill
 
     assert response.status_code == 200  # Check for a successful delete
     assert "message" in response.json
-    assert response.json["message"] == f"Skill {example_skill[skill_name]} deleted successfully"
+    assert response.json["message"] == f"Skill {example_skill["skill"][index_to_delete]} deleted successfully"
 
     # Check that the deleted skill is no longer in the list
     response = app.test_client().get('/resume/skill')
-    assert skill_name not in response.json 
+    assert skill_name not in response.json

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -85,12 +85,13 @@ def test_delete_skill():
     item_id = app.test_client().post('/resume/skill', json=example_skill).json['id']
 
     index_to_delete = 0
+    skill_name = example_skill["skill"][index_to_delete]
     response = app.test_client().delete(f'/resume/skill?index={index_to_delete}')
     assert response.json[item_id] == example_skill
 
     assert response.status_code == 200  # Check for a successful delete
     assert "message" in response.json
-    assert response.json["message"] == f"Skill {example_skill["skill"][index_to_delete]} deleted successfully"
+    assert response.json["message"] == f"Skill '{skill_name}' deleted successfully"
 
     # Check that the deleted skill is no longer in the list
     response = app.test_client().get('/resume/skill')

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -72,3 +72,26 @@ def test_skill():
 
     response = app.test_client().get('/resume/skill')
     assert response.json[item_id] == example_skill
+
+def test_delete_skill():
+    '''
+    Delete a skill and then check that it's no longer in the list
+    '''
+
+    example_skill = {
+        "skill": ["Python", "Javascript", "C++"]
+    }
+
+    item_id = app.test_client().post('/resume/skill', json=example_skill).json['id']
+
+    index_to_delete = 0  
+    skill_name = example_skill["skill"][index_to_delete]
+    response = app.test_client().delete(f'/resume/skill?index={index_to_delete}')
+
+    assert response.status_code == 200  # Check for a successful delete
+    assert "message" in response.json
+    assert response.json["message"] == f"Skill "{example_skill[skill_name]}" deleted successfully"
+
+    # Check that the deleted skill is no longer in the list
+    response = app.test_client().get('/resume/skill')
+    assert skill_name not in response.json 

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -90,7 +90,7 @@ def test_delete_skill():
 
     assert response.status_code == 200  # Check for a successful delete
     assert "message" in response.json
-    assert response.json["message"] == f"Skill "{example_skill[skill_name]}" deleted successfully"
+    assert response.json["message"] == f"Skill {example_skill[skill_name]} deleted successfully"
 
     # Check that the deleted skill is no longer in the list
     response = app.test_client().get('/resume/skill')

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -96,3 +96,4 @@ def test_delete_skill():
     # Check that the deleted skill is no longer in the list
     response = app.test_client().get('/resume/skill')
     assert skill_name not in response.json
+    


### PR DESCRIPTION
Implements delete operation for the skill route. A new test is added as well. Currently, none of the tests work because the routes don't return an 'id' key in the JSON response when a POST request is made. Let me know if I should fix that in this issue.
Closes #3 