### PR TITLE
added the route to update skills

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ def experience():
     Handle experience requests
     '''
     if request.method == 'GET':
-        return jsonify()
+        return jsonify({})
 
     if request.method == 'POST':
         return jsonify({})
@@ -66,15 +66,30 @@ def education():
     return jsonify({})
 
 
-@app.route('/resume/skill', methods=['GET', 'POST'])
+@app.route('/resume/skill', methods=['GET', 'POST', 'PUT'])
 def skill():
     '''
     Handles Skill requests
     '''
     if request.method == 'GET':
-        return jsonify({})
+        skills_data = data["skill"]
+        return jsonify(skills_data)
 
     if request.method == 'POST':
         return jsonify({})
+
+    if request.method == 'PUT':
+        skill_data = request.get_json()
+        skill_id = skill_data.get("id")
+
+        if skill_id is not None and skill_id >= 0 and skill_id < len(data["skill"]):
+            data["skill"][skill_id] = Skill(
+                skill_data.get("name"),
+                skill_data.get("proficiency"),
+                skill_data.get("logo")
+            )
+            return jsonify(data['skill'][skill_id])
+
+        return jsonify({"error": "Invalid Skill ID"}), 400
 
     return jsonify({})

--- a/test_pytest.py
+++ b/test_pytest.py
@@ -72,3 +72,32 @@ def test_skill():
 
     response = app.test_client().get('/resume/skill')
     assert response.json[item_id] == example_skill
+
+
+def test_update_skill():
+    '''
+    Update an existing skill by passing the ID in the JSON request
+    '''
+
+    updated_skill = {
+        "id": 0,
+        "name": "Updated Skill",
+        "proficiency": "5-7 years",
+        "logo": "example-logo.png"
+    }
+
+    # Perform the PUT request to update the skill without passing ID in the URL
+    response = app.test_client().put('/resume/skill', json=updated_skill)
+
+    assert response.status_code == 200
+    assert response.json["name"] == updated_skill["name"]
+
+    # Check if the skill has been updated in the list
+    get_response = app.test_client().get('/resume/skill')
+    updated_skill_list = get_response.json
+
+    id = updated_skill["id"]
+    del updated_skill["id"]
+
+    assert len(updated_skill_list) == 1
+    assert updated_skill_list[id] == updated_skill


### PR DESCRIPTION
Added a put request route to /resume/skill that accepts skill detail as JSON data and returns the updated skill.

**Testing:**

I've tested this feature by creating and updating skills. The tests are passing, ensuring the reliability of the code.